### PR TITLE
Support fields with multiple w:instrText elements

### DIFF
--- a/libraries/ref-extractor.js
+++ b/libraries/ref-extractor.js
@@ -16,10 +16,30 @@ function handleFileSelect(event) {
         var fields = [];
         
         var parsedDOM = new DOMParser().parseFromString(xmlWordFile, 'text/xml');
-        var fieldElements = parsedDOM.getElementsByTagName("w:instrText");
-
-        for (var i = 0; i < fieldElements.length; i++) {
-            fields.push(fieldElements[i].textContent);
+        
+        // Locate the beginning of complex fields (<w:fldChar w:fldCharType="begin"/>, child of <w:r>)
+        var complexFieldStarts = parsedDOM.querySelectorAll("*|fldChar[*|fldCharType=begin]");
+        
+        for (var i = 0; i < complexFieldStarts.length; i++) {
+            instrTextContent = "";
+            
+            // Visit sibling <w:r> elements until we hit the last one (<w:fldChar w:fldCharType="end"/>, child of <w:r>)
+            nextRun = complexFieldStarts[i].parentElement.nextSibling;
+            while (nextRun) {
+              endRun = nextRun.querySelectorAll("*|fldChar[*|fldCharType=end]");
+              if (endRun.length != 0) {
+                  break;
+              }
+              
+              // Concatenate textContents of <w:instrText/> elements within complex field
+              instrTextFields = nextRun.getElementsByTagName("w:instrText");
+              for (let i = 0; i < instrTextFields.length; i++) {
+                  instrTextContent += instrTextFields[i].textContent;
+              }
+              
+              nextRun = nextRun.nextSibling;
+            }
+            fields.push(instrTextContent);
         }
         
         return(fields);


### PR DESCRIPTION
Closes https://github.com/rmzelle/ref-extractor/issues/21

As discussed at http://officeopenxml.com/WPfields.php, complex Word fields like those used by Zotero and Mendeley can have multiple `<w:instrText/>` elements. The general structure of complex fields is shown below. The current PR loops over all the `<w:r>` run elements and concatenates the content of all `<w:instrText/>` elements within a single complex field. Previous such fields with multiple `<w:instrText/>` elements were silently ignored.

```xml
<w:r>
  <w:fldChar w:fldCharType="begin"/>
</w:r>
<w:r>
  <w:instrText xml:space="preserve"> DATE </w:instrText>
</w:r>
<w:r>
  <w:fldChar w:fldCharType="separate"/>
</w:r>
<w:r>
  <w:t>12/31/2005</w:t>
</w:r>
<w:r>
  <w:fldChar w:fldCharType="end"/>
</w:r>
```