### PR TITLE
Add support for ODT files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 # Reference Extractor
 
-[Reference Extractor](https://rintze.zelle.me/ref-extractor/) is a free online tool to extract [Zotero](https://www.zotero.org/) and [Mendeley](https://www.mendeley.com/) references from Microsoft Word .docx documents.
-It only works with *active* citations that have been inserted through the Zotero or Mendeley word processor plugins, and that haven't been converted to plain text.
+[Reference Extractor](https://rintze.zelle.me/ref-extractor/) is a free online tool to extract [Zotero](https://www.zotero.org/) and [Mendeley](https://www.mendeley.com/) references from Microsoft Word and LibreOffice documents.
+References must have been inserted with the Zotero or Mendeley word processor plugins and must not have been converted to plain text.
 
 Reference extractor allows you to:
 
 * **Extract** Zotero and Mendeley references and save them to CSL JSON, BibTeX, or RIS format, or as a rendered bibliography in APA style.  
   
-  *Scenario 1*: You lost your Zotero/Mendeley library but still have your Word documents.
-  Extraction allows you to recover the items you cited in your Word documents and import them back into your reference manager. 
-  Note that imported items won't be linked to the items in the Word document you extracted them from.  
+  *Scenario 1*: You lost your Zotero/Mendeley library but still have your documents.
+  Extraction allows you to recover the items you cited in your documents and import them back into your reference manager. 
+  Note that imported items won't be linked to the items in the document you extracted them from.  
   
-  *Scenario 2*: Somebody sent you a Word document and you would like to get the cited items into your own reference manager library. 
+  *Scenario 2*: Somebody sent you a document and you would like to get the cited items into your own reference manager library. 
 * **Select** the original cited items in your existing Zotero libraries *[only available for Zotero]*.
   Once items are selected in Zotero, you can drag the items into a new collection or apply a tag.
   
   *Scenario*: You wish to create a collection for the items you've cited in a manuscript.
 * **Count** the number of times each item has been cited.
-* **Identify** the [Citation Style Language](https://citationstyles.org/) citation style used in the Word document.
+* **Identify** the [Citation Style Language](https://citationstyles.org/) citation style used in the document.
 
 ## Tips for use
 
@@ -28,7 +28,7 @@ Once you have successfully extracted the references from a document, the output,
 To import a downloaded CSL JSON, BibTeX, or RIS file into Zotero, open Zotero's File menu, select "Import..." and select the downloaded output file.
 Or, if you used the "Copy to clipboard" button of this tool, select "Import from Clipboard".
 
-The format with highest fidelity is CSL JSON, as this is the format used by Zotero and Mendeley to embed item metadata in Word documents.
+The format with highest fidelity is CSL JSON, as this is the format used by Zotero and Mendeley to embed item metadata in word processor documents.
 All other output formats involve a format conversion.
 If you discover issues with the BibTeX or RIS output formats, but need a format other than CSL JSON, try importing the CSL JSON file into Zotero, and then use Zotero to convert the references to the desired output format.
 
@@ -43,26 +43,26 @@ If you found this tool useful, please support this project by starring this GitH
 
 ## Troubleshooting
 
-If Reference Extractor doesn't work or find any items in your Word document, there are several possible causes:
+If Reference Extractor doesn't work or find any items in your word processor document, there are several possible causes:
 
-* Make sure your Word document has been saved in the ".docx" format
+* Make sure your Word document has been saved in the ".docx" format, or your LibreOffice document in the ".odt" format
 * Try a different browser, like Firefox or Google Chrome
 * If you have JavaScript disabled (e.g. by using a browser extension like [NoScript](https://noscript.net/)), enable JavaScript for this webpage
-* The citations in the Word document might not (or no longer) be [active field codes](https://www.zotero.org/support/kb/word_field_codes).
+* The citations in the document might not (or no longer) be [active field codes](https://www.zotero.org/support/kb/word_field_codes).
   Active field codes have grey shading by default, while inactive citations have white shading and look and behave like regular text.
   You can also confirm citations are active by toggling the field codes by pressing <kbd>Alt</kbd>+<kbd>F9</kbd> or <kbd>Option</kbd>+<kbd>F9</kbd> in Word.
   After pressing this shortcut, active Zotero and Mendeley field codes will expand and show the embedded citation metadata.
   Toggled Zotero fields start with "ADDIN ZOTERO_ITEM CSL_CITATION", and toggled Mendeley fields start with "ADDIN CSL_CITATION".
-* The citations in the Word document have been inserted with a different reference manager.
+* The citations in the document have been inserted with a different reference manager.
 * [Zotero] For documents with over 220 references, the "Select in Zotero" links may not work correctly.
   This issue appears to be limited to Windows.
   Either only about 220 items are selected in Zotero, or no items are selected at all.
-  If this happens, a workaround is to split your Word document into multiple Word documents that each have a reference count under this limit.
-* [Zotero] For older Word documents with Zotero references, note that Zotero [started](https://github.com/zotero/zotero-word-for-windows-integration/issues/30#issuecomment-285073023) offering embedded metadata in 2012 with Zotero 3.0.
+  If this happens, a workaround is to split your document into multiple documents that each have a reference count under this limit.
+* [Zotero] For older documents with Zotero references, note that Zotero [started](https://github.com/zotero/zotero-word-for-windows-integration/issues/30#issuecomment-285073023) offering embedded metadata in 2012 with Zotero 3.0.
   Documents last updated with earlier versions of Zotero don't contain extractable citations.
   For documents last updated with Zotero 3.x and 4.x, extraction is only possible if the option "Store references in document" was checked in the Zotero document preferences.
   Zotero 5.x always embeds item metadata.
-* [Zotero] For Word documents with Zotero references, references must be stored as "Fields", not "Bookmarks".  This can be changed for existing documents through the [Zotero document preferences](https://www.zotero.org/support/word_processor_plugin_usage#document_preferences).
+* [Zotero] For Word documents with Zotero references, references must be stored as "Fields", not "Bookmarks". For LibreOffice documents, references must be stored as "ReferenceMarks", not "Bookmarks". This can be changed for existing documents through the [Zotero document preferences](https://www.zotero.org/support/word_processor_plugin_usage#document_preferences).
 
 If you can't find a solution, https://www.zotero.org/support/kb/importing_formatted_bibliographies describes several alternative methods that e.g. work with plain text citations.
 

--- a/index.html
+++ b/index.html
@@ -38,13 +38,9 @@
     <nav class="navbar navbar-expand-md navbar-dark" style="background-color: #6c757d;">
       <div class="container">
         <span class="navbar-brand mb-0 h1">Reference Extractor</span>
-        <div class="collapse navbar-collapse" id="navbarCollapse">
-          <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-              <a class="nav-link" href="#">Extract Zotero and Mendeley references from Microsoft Word and LibreOffice (OpenDocument) files</a>
-            </li>
-          </ul>
-        </div>
+        <span class="navbar-text">
+          Extract Zotero and Mendeley references from Microsoft Word and LibreOffice documents
+        </span>
       </div>
     </nav>
   </header>
@@ -54,9 +50,9 @@
     <div class="container">
       <div class="row my-3">
         <div class="col-lg-8">
-          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word .docx and LibreOffice .odt files.
-            It only works with <em>active</em> citations that have been inserted through the Zotero or Mendeley word processor plugins, and that haven’t been converted to plain text.
-            The tool runs locally on your computer, keeping your documents and extracted citations private.</p>
+          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word and LibreOffice documents.
+            References must have been inserted with the Zotero or Mendeley word processor plugins and must not have been converted to plain text.
+            The tool runs entirely on your own computer, keeping your documents and citations private and secure.</p>
           <hr>
           <h4 class="text-center">Input</h4>
           <div class="container">
@@ -72,7 +68,7 @@
                 <div class="form-group">
                   <input id="file_upload" type="file">
                   <small id="file_upload_help" class="form-text text-muted">
-                    Select your .docx or .odt file
+                    Select your .docx (Word) or .odt (LibreOffice) file
                   </small>
                 </div>
               </form>
@@ -124,7 +120,7 @@
           </div>
           <hr>
           <h4>About Reference Extractor</h4>
-          <p>Reference extractor allows you to:</p>
+          <p>Reference Extractor allows you to:</p>
           <ul>
             <li>
               <p><strong>Extract</strong> Zotero and Mendeley references and save them to CSL JSON, BibTeX, or RIS format, or as a rendered bibliography in APA style.</p>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <div class="container">
       <div class="row my-3">
         <div class="col-lg-8">
-          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word.docx and LibreOffice .odt files.
+          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word .docx and LibreOffice .odt files.
             It only works with <em>active</em> citations that have been inserted through the Zotero or Mendeley word processor plugins, and that haven’t been converted to plain text.
             The tool runs locally on your computer, keeping your documents and extracted citations private.</p>
           <hr>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <div class="collapse navbar-collapse" id="navbarCollapse">
           <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-              <a class="nav-link" href="#">Extract Zotero and Mendeley references from OpenDocument (LibreOffice, OpenOffice) files</a>
+              <a class="nav-link" href="#">Extract Zotero and Mendeley references from Microsoft Word and OpenDocument (LibreOffice, OpenOffice) files</a>
             </li>
           </ul>
         </div>
@@ -54,7 +54,7 @@
     <div class="container">
       <div class="row my-3">
         <div class="col-lg-8">
-          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from OpenDocument .odt files.
+          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word.docx and OpenDocument .odt files.
             It only works with <em>active</em> citations that have been inserted through the Zotero or Mendeley word processor plugins, and that haven’t been converted to plain text.
             The tool runs locally on your computer, keeping your documents and extracted citations private.</p>
           <hr>
@@ -72,7 +72,7 @@
                 <div class="form-group">
                   <input id="file_upload" type="file">
                   <small id="file_upload_help" class="form-text text-muted">
-                    Select your .odt file
+                    Select your .docx or .odt file
                   </small>
                 </div>
               </form>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <div class="collapse navbar-collapse" id="navbarCollapse">
           <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-              <a class="nav-link" href="#">Extract Zotero and Mendeley references from Microsoft Word files</a>
+              <a class="nav-link" href="#">Extract Zotero and Mendeley references from OpenDocument (LibreOffice, OpenOffice) files</a>
             </li>
           </ul>
         </div>
@@ -54,9 +54,9 @@
     <div class="container">
       <div class="row my-3">
         <div class="col-lg-8">
-          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word .docx documents.
+          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from OpenDocument .odt files.
             It only works with <em>active</em> citations that have been inserted through the Zotero or Mendeley word processor plugins, and that haven’t been converted to plain text.
-            The tool runs locally on your computer, keeping your Word documents and extracted citations private.</p>
+            The tool runs locally on your computer, keeping your documents and extracted citations private.</p>
           <hr>
           <h4 class="text-center">Input</h4>
           <div class="container">
@@ -72,7 +72,7 @@
                 <div class="form-group">
                   <input id="file_upload" type="file">
                   <small id="file_upload_help" class="form-text text-muted">
-                    Select your .docx Word file
+                    Select your .odt file
                   </small>
                 </div>
               </form>
@@ -128,10 +128,10 @@
           <ul>
             <li>
               <p><strong>Extract</strong> Zotero and Mendeley references and save them to CSL JSON, BibTeX, or RIS format, or as a rendered bibliography in APA style.</p>
-              <p><em>Scenario 1</em>: You lost your Zotero/Mendeley library but still have your Word documents.
-                Extraction allows you to recover the items you cited in your Word documents and import them back into your reference manager.
-                Note that imported items won’t be linked to the items in the Word document you extracted them from.</p>
-              <p><em>Scenario 2</em>: Somebody sent you a Word document and you would like to get the cited items into your own reference manager library.</p>
+              <p><em>Scenario 1</em>: You lost your Zotero/Mendeley library but still have your documents.
+                Extraction allows you to recover the items you cited in your documents and import them back into your reference manager.
+                Note that imported items won’t be linked to the items in the document you extracted them from.</p>
+              <p><em>Scenario 2</em>: Somebody sent you a document and you would like to get the cited items into your own reference manager library.</p>
             </li>
             <li>
               <p><strong>Select</strong> the original cited items in your existing Zotero libraries <em>[only available for Zotero]</em>.
@@ -142,7 +142,7 @@
               <p><strong>Count</strong> the number of times each item has been cited.</p>
             </li>
             <li>
-              <p><strong>Identify</strong> the <a href="https://citationstyles.org/">Citation Style Language</a> citation style used in the Word document.</p>
+              <p><strong>Identify</strong> the <a href="https://citationstyles.org/">Citation Style Language</a> citation style used in the document.</p>
             </li>
           </ul>
           <p>Check the <a href="https://github.com/rmzelle/ref-extractor#reference-extractor">README</a> for more information about this tool and how to use it.</p>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <div class="collapse navbar-collapse" id="navbarCollapse">
           <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-              <a class="nav-link" href="#">Extract Zotero and Mendeley references from Microsoft Word and OpenDocument (LibreOffice, OpenOffice) files</a>
+              <a class="nav-link" href="#">Extract Zotero and Mendeley references from Microsoft Word and LibreOffice (OpenDocument) files</a>
             </li>
           </ul>
         </div>
@@ -54,7 +54,7 @@
     <div class="container">
       <div class="row my-3">
         <div class="col-lg-8">
-          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word.docx and OpenDocument .odt files.
+          <p><strong>Reference Extractor</strong> is a free tool to extract <a href="https://www.zotero.org/">Zotero</a> and <a href="https://www.mendeley.com/">Mendeley</a> references from Microsoft Word.docx and LibreOffice .odt files.
             It only works with <em>active</em> citations that have been inserted through the Zotero or Mendeley word processor plugins, and that haven’t been converted to plain text.
             The tool runs locally on your computer, keeping your documents and extracted citations private.</p>
           <hr>

--- a/libraries/ref-extractor.js
+++ b/libraries/ref-extractor.js
@@ -71,6 +71,8 @@ function handleFileSelect(event) {
                 fields.push(instrTextContent);
             }
         } else if (documentType == "OpenDocument") {
+            // when using reference marks, Zotero stores citations in the
+            // text:name attribute of <text:reference-mark-start> elements
             var referenceMarks = parsedDOM.querySelectorAll("*|reference-mark-start[*|name]");
 
             for (var i = 0; i < referenceMarks.length; i++) {

--- a/libraries/ref-extractor.js
+++ b/libraries/ref-extractor.js
@@ -181,12 +181,10 @@ function processExtractedFields(fields) {
     for (var i = 0; i < fields.length; i++) {
       var field = fields[i].trim();
       
-      // Test if field is a Zotero or Mendeley field
-      // In Word files:
-      // Zotero fields are prefixed with "ADDIN ZOTERO_ITEM CSL_CITATION"
+      // Check that field is a Zotero or Mendeley field
       // Mendeley fields are prefixed with "ADDIN CSL_CITATION"
-      // In OpenDocument files:
-      // Zotero fields are prefixed with "ZOTERO_ITEM CSL_CITATION"
+      // In Word files, Zotero fields are prefixed with "ADDIN ZOTERO_ITEM CSL_CITATION"
+      // In ODT files, Zotero fields are prefixed only with "ZOTERO_ITEM CSL_CITATION"
       var cslFieldPrefix = /^(ADDIN )?(ZOTERO_ITEM )?CSL_CITATION/;
       if (cslFieldPrefix.test(field)) {
         field = field.replace(cslFieldPrefix,"").trim();


### PR DESCRIPTION
First of all, **thank you** for this tool and for the documentation on the Wiki pages. A few months ago, I wanted to select the Zotero items I had cited in a document I wrote. As a Linux user, I use only LibreOffice, and because saving a document as a .docx breaks the links, the Reference Extractor did not work for me. However, thanks to your documentation and looking at your code, I could write a small Python script specifically tailored for my uses (you can read it [as a gist](https://gist.github.com/nchachereau/3904f4e559a6ed4211ed97eb6c2d47b6)).

Back then I wrote it in Python because I was unfamiliar with a lot of the Javascript features used in your code (async and `then`, arrow functions…). But having learnt about these in the meantime, I thought I would try to port my code to the official Reference Extractor, as a way of thanking you and making this tool even more useful.

Take a look and tell me if you think this would be of interest.

One last thing: the Zotero plugin for LibreOffice allows the user to choose, for some CSL styles, between "Reference marks" and "Bookmarks". The former being recommended, the latter allowing a document to be shared between LibreOffice and Microsoft Word ([official documentation](https://www.zotero.org/support/libreoffice_writer_plugin_usage#document_preferences)). As it stands, the code only works with Reference marks. From the looks of it, supporting Bookmarks introduces a bit more complexity but seems feasible. I wanted to get your feedback on this as it stands, but I will try to add Bookmarks if you are open to the general idea of adding support for ODT.